### PR TITLE
Add CI, and remove dist/jAER.jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /Thumbs.db
 /bin
 /build
-/dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: java
+script: ant jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 script: ant jar
+jdk: oraclejdk8
 before_deploy:
   - zip jaer-dist.zip jAERViewer1.5_linux.sh jAERViewer1.5_win32.exe jAERViewer1.5_win64.exe SplashScreen.gif dist/jAER.jar jars/* jars/javacv/* jars/jogl/* jars/usb4java/*
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,9 @@
 language: java
 script: ant jar
+deploy:
+  provider: releases
+  api_key: $GITHUB_TOKEN
+  file: "dist/jAER.jar"
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: java
+sudo: false
+dist: trusty
 script: ant jar
 jdk: oraclejdk8
 before_deploy:
-  - zip jaer-dist.zip jAERViewer1.5_linux.sh jAERViewer1.5_win32.exe jAERViewer1.5_win64.exe SplashScreen.gif dist/jAER.jar jars/* jars/javacv/* jars/jogl/* jars/usb4java/*
+  - zip -r jaer-dist.zip jAERViewer1.5_linux.sh jAERViewer1.5_win32.exe jAERViewer1.5_win64.exe SplashScreen.gif dist/ jars/
 deploy:
   provider: releases
   api_key: $GITHUB_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: java
 script: ant jar
+before_deploy:
+  - zip jaer-dist.zip jAERViewer1.5_linux.sh jAERViewer1.5_win32.exe jAERViewer1.5_win64.exe SplashScreen.gif dist/jAER.jar jars/* jars/javacv/* jars/jogl/* jars/usb4java/*
 deploy:
   provider: releases
   api_key: $GITHUB_TOKEN
-  file: "dist/jAER.jar"
+  file: jaer-dist.zip
   skip_cleanup: true
   on:
     tags: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jAER
 Java tools for Address-Event Representation (AER) neuromorphic processing.
 
-[![Build Status](https://travis-ci.org/jo-m/jaer.svg?branch=master)](https://travis-ci.org/jo-m/jaer)
+[![Build Status](https://travis-ci.org/SensorsInI/jaer.svg?branch=master)](https://travis-ci.org/SensorsInI/jaer)
 
 Welcome to the jAER Open Source Project
 Real time sensory-motor processing for event-based sensors and systems
@@ -10,7 +10,7 @@ This project has been moved here from SourceForge. Commits are now disabled ther
 
 ## Download
 
-You can find the latest releases at <https://github.com/jo-m/jaer/releases>.
+You can find the latest releases at <https://github.com/SensorsInI/jaer/releases>.
 
 To build yourself, close the repo and run
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jaer
+# jAER
 Java tools for Address-Event Representation (AER) neuromorphic processing.
 
 [![Build Status](https://travis-ci.org/jo-m/jaer.svg?branch=master)](https://travis-ci.org/jo-m/jaer)
@@ -7,6 +7,16 @@ Welcome to the jAER Open Source Project
 Real time sensory-motor processing for event-based sensors and systems
 Founded in 2007.
 This project has been moved here from SourceForge. Commits are now disabled there.
+
+## Download
+
+You can find the latest releases at <https://github.com/jo-m/jaer/releases>.
+
+To build yourself, close the repo and run
+
+    ant jar
+
+## Support
 
 See https://sourceforge.net/p/jaer/wiki/Home/ for user guide (ignoring the sourceforge subversion installation instructions there)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # jaer
 Java tools for Address-Event Representation (AER) neuromorphic processing.
 
+[![Build Status](https://travis-ci.org/jo-m/jaer.svg?branch=master)](https://travis-ci.org/jo-m/jaer)
+
 Welcome to the jAER Open Source Project
 Real time sensory-motor processing for event-based sensors and systems
 Founded in 2007.

--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/ch/unizh/ini/jaer/projects/rbodo/opticalflow/MotionFlowStatistics.java
+++ b/src/ch/unizh/ini/jaer/projects/rbodo/opticalflow/MotionFlowStatistics.java
@@ -207,8 +207,7 @@ public class MotionFlowStatistics {
          * onto circumferences around center.
          */
         public float meanGlobalVx, sdGlobalVx, meanGlobalVy, sdGlobalVy, meanGlobalRotation, meanGlobalTrans, sdGlobalTrans,
-                sdGlobalRotation, meanGlobalExpansion, sdGlobalExpansion;
-        public float meanGlobalSpeed;
+                sdGlobalRotation, meanGlobalExpansion, sdGlobalExpansion, meanGlobalSpeed;
         private final Measurand globalVx, globalVy, globalRotation, globalExpansion, globalSpeed;
         private int rx, ry;
         private int subSizeX, subSizeY;

--- a/src/ch/unizh/ini/jaer/projects/tobi/billcatcher/BillCatcher.java
+++ b/src/ch/unizh/ini/jaer/projects/tobi/billcatcher/BillCatcher.java
@@ -137,7 +137,7 @@ public class BillCatcher extends EventFilter2D implements FrameAnnotater {
     }
 
     boolean isBillFalling(EventPacket<?> in) {
-        translationalMotion = motionFilter.getMotionFlowStatistics().getGlobalMotion().getGlobalVy().getMean();
+        translationalMotion = (float)motionFilter.getMotionFlowStatistics().getGlobalMotion().getGlobalVy().getMean();
         boolean moving = (translationalMotion < -motionThresholdPixelsPerSec);
         float rate = in.getEventRateHz();
         return moving && (rate > (minkEPSToGrab * 1e3f));


### PR DESCRIPTION
Hi all!
Why not add continuous integration, when we can have it for free?
The CI script will automatically build the jar, zip it up with the dependencies, and upload it to github releases (only for tagged git commits). This way, the jar does not have to be checked in anymore.