### PR TITLE
SEC-DVS-UDP

### DIFF
--- a/src/net/sf/jaer/eventio/AEUnicastInput.java
+++ b/src/net/sf/jaer/eventio/AEUnicastInput.java
@@ -516,7 +516,12 @@ public class AEUnicastInput implements AEUnicastSettings, PropertyChangeListener
                                 }
 
                             }
-                            
+                        
+                        }
+                        else {
+                            // In this case, the buffer is misaligned with the 4-byte packet format; 
+                            // Drop a byte and try again
+                            byte dontCare = buffer.get();
                         }
                     }
                 }


### PR DESCRIPTION
Catch the case where SEC-DVS-UDP stream should become misaligned with 4-byte packet format.