### PR TITLE
Roilogic

### DIFF
--- a/src/eu/seebetter/ini/chips/davis/Davis128.java
+++ b/src/eu/seebetter/ini/chips/davis/Davis128.java
@@ -27,8 +27,8 @@ public class Davis128 extends DavisBaseCamera {
 		davisRenderer.setMaxADC(DavisChip.MAX_ADC);
 		setRenderer(davisRenderer);
 
-		setApsFirstPixelReadOut(new Point(getSizeX() - 1, getSizeY() - 1));
-		setApsLastPixelReadOut(new Point(0, 0));
+		setApsFirstPixelReadOut(new Point(0, getSizeY() - 1));
+		setApsLastPixelReadOut(new Point(getSizeX() - 1, 0));
 	}
 
 	public Davis128(final HardwareInterface hardwareInterface) {

--- a/src/eu/seebetter/ini/chips/davis/Davis128.java
+++ b/src/eu/seebetter/ini/chips/davis/Davis128.java
@@ -27,8 +27,8 @@ public class Davis128 extends DavisBaseCamera {
 		davisRenderer.setMaxADC(DavisChip.MAX_ADC);
 		setRenderer(davisRenderer);
 
-		setApsFirstPixelReadOut(new Point(0, getSizeY() - 1));
-		setApsLastPixelReadOut(new Point(getSizeX() - 1, 0));
+		setApsFirstPixelReadOut(new Point(0, 0));
+		setApsLastPixelReadOut(new Point(getSizeX() - 1, getSizeY() - 1));
 	}
 
 	public Davis128(final HardwareInterface hardwareInterface) {

--- a/src/eu/seebetter/ini/chips/davis/Davis128Color.java
+++ b/src/eu/seebetter/ini/chips/davis/Davis128Color.java
@@ -31,8 +31,8 @@ public class Davis128Color extends DavisBaseCamera {
 		davisRenderer.setMaxADC(DavisChip.MAX_ADC);
 		setRenderer(davisRenderer);
 
-		setApsFirstPixelReadOut(new Point(0, getSizeY() - 1));
-		setApsLastPixelReadOut(new Point(getSizeX() - 1, 0));
+		setApsFirstPixelReadOut(new Point(0, 0));
+		setApsLastPixelReadOut(new Point(getSizeX() - 1, getSizeY() - 1));
 	}
 
 	public Davis128Color(final HardwareInterface hardwareInterface) {

--- a/src/eu/seebetter/ini/chips/davis/Davis128Color.java
+++ b/src/eu/seebetter/ini/chips/davis/Davis128Color.java
@@ -31,8 +31,8 @@ public class Davis128Color extends DavisBaseCamera {
 		davisRenderer.setMaxADC(DavisChip.MAX_ADC);
 		setRenderer(davisRenderer);
 
-		setApsFirstPixelReadOut(new Point(getSizeX() - 1, getSizeY() - 1));
-		setApsLastPixelReadOut(new Point(0, 0));
+		setApsFirstPixelReadOut(new Point(0, getSizeY() - 1));
+		setApsLastPixelReadOut(new Point(getSizeX() - 1, 0));
 	}
 
 	public Davis128Color(final HardwareInterface hardwareInterface) {

--- a/src/eu/seebetter/ini/chips/davis/Davis208PixelParade.java
+++ b/src/eu/seebetter/ini/chips/davis/Davis208PixelParade.java
@@ -27,8 +27,8 @@ public class Davis208PixelParade extends DavisBaseCamera {
 		davisRenderer.setMaxADC(DavisChip.MAX_ADC);
 		setRenderer(davisRenderer);
 
-		setApsFirstPixelReadOut(new Point(getSizeX() - 1, 0));
-		setApsLastPixelReadOut(new Point(0, getSizeY() - 1));
+		setApsFirstPixelReadOut(new Point(0, 0));
+		setApsLastPixelReadOut(new Point(getSizeX() - 1, getSizeY() - 1));
 	}
 
 	public Davis208PixelParade(final HardwareInterface hardwareInterface) {

--- a/src/eu/seebetter/ini/chips/davis/Davis208PixelParadeColor.java
+++ b/src/eu/seebetter/ini/chips/davis/Davis208PixelParadeColor.java
@@ -32,8 +32,8 @@ public class Davis208PixelParadeColor extends DavisBaseCamera {
 		davisRenderer.setMaxADC(DavisChip.MAX_ADC);
 		setRenderer(davisRenderer);
 
-		setApsFirstPixelReadOut(new Point(getSizeX() - 1, 0));
-		setApsLastPixelReadOut(new Point(0, getSizeY() - 1));
+		setApsFirstPixelReadOut(new Point(0, 0));
+		setApsLastPixelReadOut(new Point(getSizeX() - 1, getSizeY() - 1));
 	}
 
 	public Davis208PixelParadeColor(final HardwareInterface hardwareInterface) {

--- a/src/eu/seebetter/ini/chips/davis/DavisBaseCamera.java
+++ b/src/eu/seebetter/ini/chips/davis/DavisBaseCamera.java
@@ -1015,7 +1015,7 @@ abstract public class DavisBaseCamera extends DavisChip implements RemoteControl
 
         @Override
         public void display(final GLAutoDrawable drawable) {
-            super.display(drawable); 
+            super.display(drawable);
 
             if (exposureRenderer == null) {
                 exposureRenderer = new TextRenderer(new Font("SansSerif", Font.PLAIN, DavisDisplayMethod.FONTSIZE), true, true);
@@ -1173,7 +1173,7 @@ abstract public class DavisBaseCamera extends DavisChip implements RemoteControl
                     getFrameRateHz());
             final float scale = TextRendererScale.draw3dScale(exposureRenderer, s, getChipCanvas().getScale(), getSizeX(), 1f);
             // determine width of string in pixels and scale accordingly
-            exposureRenderer.draw3D(s, 0, getSizeY() + (DavisDisplayMethod.FONTSIZE / 2) * scale, 0, scale);
+            exposureRenderer.draw3D(s, 0, getSizeY() + ((DavisDisplayMethod.FONTSIZE / 2) * scale), 0, scale);
             exposureRenderer.end3DRendering();
 
             final int nframes = getFrameCount() % DavisDisplayMethod.FRAME_COUNTER_BAR_LENGTH_FRAMES;
@@ -1219,29 +1219,6 @@ abstract public class DavisBaseCamera extends DavisChip implements RemoteControl
             } catch (final HardwareInterfaceException e) {
                 // Ignore.
             }
-        }
-    }
-
-    public void configureROIRegion0(final Point cornerLL, final Point cornerUR) {
-        // First program the new sizes into logic.
-        if ((getHardwareInterface() != null) && (getHardwareInterface() instanceof CypressFX3)) {
-            final CypressFX3 fx3HwIntf = (CypressFX3) getHardwareInterface();
-            final SPIConfigSequence configSequence = fx3HwIntf.new SPIConfigSequence();
-
-            try {
-                configSequence.addConfig(CypressFX3.FPGA_APS, (short) 9, cornerLL.x);
-                configSequence.addConfig(CypressFX3.FPGA_APS, (short) 10, cornerLL.y);
-                configSequence.addConfig(CypressFX3.FPGA_APS, (short) 11, cornerUR.x);
-                configSequence.addConfig(CypressFX3.FPGA_APS, (short) 12, cornerUR.y);
-
-                configSequence.sendConfigSequence();
-            } catch (final HardwareInterfaceException e) {
-                // Ignore.
-            }
-
-            // Then update first/last pixel coordinates.
-            setApsFirstPixelReadOut(new Point(0, (cornerUR.y - cornerLL.y)));
-            setApsLastPixelReadOut(new Point((cornerUR.x - cornerLL.x), 0));
         }
     }
 

--- a/src/net/sf/jaer/hardwareinterface/usb/cypressfx3libusb/DAViSFX3HardwareInterface.java
+++ b/src/net/sf/jaer/hardwareinterface/usb/cypressfx3libusb/DAViSFX3HardwareInterface.java
@@ -43,8 +43,8 @@ public class DAViSFX3HardwareInterface extends CypressFX3Biasgen {
 	/** The USB product ID of this device */
 	static public final short PID_FX3 = (short) 0x841A;
 	static public final short PID_FX2 = (short) 0x841B;
-	static public final int REQUIRED_FIRMWARE_VERSION_FX3 = 3;
-	static public final int REQUIRED_FIRMWARE_VERSION_FX2 = 3;
+	static public final int REQUIRED_FIRMWARE_VERSION_FX3 = 4;
+	static public final int REQUIRED_FIRMWARE_VERSION_FX2 = 4;
 	static public final int REQUIRED_LOGIC_REVISION_FX3 = 9912;
 	static public final int REQUIRED_LOGIC_REVISION_FX2 = 9912;
 

--- a/src/net/sf/jaer/hardwareinterface/usb/cypressfx3libusb/DAViSFX3HardwareInterface.java
+++ b/src/net/sf/jaer/hardwareinterface/usb/cypressfx3libusb/DAViSFX3HardwareInterface.java
@@ -552,6 +552,9 @@ public class DAViSFX3HardwareInterface extends CypressFX3Biasgen {
 									yPos = temp;
 								}
 
+								// NOTE 09.2017: logic now uses upper left (CG format) as output.
+								yPos = (apsInvertXY) ? (apsSizeX - 1 - yPos) : (apsSizeY - 1 - yPos);
+
 								apsCountY[apsCurrentReadoutType]++;
 
 								// RGB support: first 320 pixels are even, then odd.

--- a/src/net/sf/jaer/hardwareinterface/usb/cypressfx3libusb/DAViSFX3HardwareInterface.java
+++ b/src/net/sf/jaer/hardwareinterface/usb/cypressfx3libusb/DAViSFX3HardwareInterface.java
@@ -45,8 +45,8 @@ public class DAViSFX3HardwareInterface extends CypressFX3Biasgen {
 	static public final short PID_FX2 = (short) 0x841B;
 	static public final int REQUIRED_FIRMWARE_VERSION_FX3 = 3;
 	static public final int REQUIRED_FIRMWARE_VERSION_FX2 = 3;
-	static public final int REQUIRED_LOGIC_REVISION_FX3 = 9910;
-	static public final int REQUIRED_LOGIC_REVISION_FX2 = 9880;
+	static public final int REQUIRED_LOGIC_REVISION_FX3 = 9912;
+	static public final int REQUIRED_LOGIC_REVISION_FX2 = 9912;
 
 	static public final float FX2_USB_CLOCK_FREQ = 30.0f;
 	static public final float FX3_CLOCK_CORRECTION = 1.008f;
@@ -145,14 +145,6 @@ public class DAViSFX3HardwareInterface extends CypressFX3Biasgen {
 		private final int apsSizeX;
 		private final int apsSizeY;
 
-		private static final int APS_ROI_REGIONS_MAX = 4;
-		private int apsROIUpdate;
-		private int apsROITmpData;
-		private final short apsROISizeX[];
-		private final short apsROISizeY[];
-		private final short apsROIPositionX[];
-		private final short apsROIPositionY[];
-
 		private static final int IMU_DATA_LENGTH = 7;
 		private final short[] imuEvents;
 		private final boolean imuFlipX;
@@ -177,11 +169,6 @@ public class DAViSFX3HardwareInterface extends CypressFX3Biasgen {
 			apsCountX = new short[RetinaAEReader.APS_READOUT_TYPES_NUM];
 			apsCountY = new short[RetinaAEReader.APS_READOUT_TYPES_NUM];
 
-			apsROISizeX = new short[RetinaAEReader.APS_ROI_REGIONS_MAX];
-			apsROISizeY = new short[RetinaAEReader.APS_ROI_REGIONS_MAX];
-			apsROIPositionX = new short[RetinaAEReader.APS_ROI_REGIONS_MAX];
-			apsROIPositionY = new short[RetinaAEReader.APS_ROI_REGIONS_MAX];
-
 			initFrame();
 
 			imuEvents = new short[RetinaAEReader.IMU_DATA_LENGTH];
@@ -190,12 +177,6 @@ public class DAViSFX3HardwareInterface extends CypressFX3Biasgen {
 
 			apsSizeX = spiConfigReceive(CypressFX3.FPGA_APS, (short) 0);
 			apsSizeY = spiConfigReceive(CypressFX3.FPGA_APS, (short) 1);
-
-			// Set intial ROI sizes.
-			apsROIPositionX[0] = 0;
-			apsROIPositionY[0] = 0;
-			apsROISizeX[0] = (short) apsSizeX;
-			apsROISizeY[0] = (short) apsSizeY;
 
 			final int chipAPSStreamStart = spiConfigReceive(CypressFX3.FPGA_APS, (short) 2);
 			apsInvertXY = (chipAPSStreamStart & 0x04) != 0;
@@ -222,37 +203,10 @@ public class DAViSFX3HardwareInterface extends CypressFX3Biasgen {
 			}
 		}
 
-		private void updateROISizes() {
-			// Calculate APS ROI sizes for each region.
-			for (int i = 0; i < RetinaAEReader.APS_ROI_REGIONS_MAX; i++) {
-				final short startColumn = apsROIPositionX[i];
-				final short startRow = apsROIPositionY[i];
-				final short endColumn = apsROISizeX[i];
-				final short endRow = apsROISizeY[i];
-
-				// Position is already set to startCol/Row, so we don't have to reset
-				// it here. We only have to calculate size from start and end.
-				if (startColumn < apsSizeX) {
-					apsROISizeX[i] = (short) ((endColumn + 1) - startColumn);
-					apsROISizeY[i] = (short) ((endRow + 1) - startRow);
-				}
-				else {
-					// Turn off this ROI region.
-					apsROISizeX[i] = apsROISizeY[i] = 0;
-					apsROIPositionX[i] = apsROIPositionY[i] = 0;
-				}
-			}
-		}
-
 		private void initFrame() {
 			apsCurrentReadoutType = RetinaAEReader.APS_READOUT_RESET;
 			Arrays.fill(apsCountX, 0, RetinaAEReader.APS_READOUT_TYPES_NUM, (short) 0);
 			Arrays.fill(apsCountY, 0, RetinaAEReader.APS_READOUT_TYPES_NUM, (short) 0);
-
-			// Only update ROI info if it was sent by the device.
-			if (apsROIUpdate != 0) {
-				updateROISizes();
-			}
 		}
 
 		private boolean ensureCapacity(final AEPacketRaw buffer, final int capacity) {
@@ -376,7 +330,7 @@ public class DAViSFX3HardwareInterface extends CypressFX3Biasgen {
 										CypressFX3.log.fine("APS Frame End event received.");
 
 										for (int j = 0; j < RetinaAEReader.APS_READOUT_TYPES_NUM; j++) {
-											int checkValue = apsROISizeX[0];
+											int checkValue = apsSizeX;
 
 											// Check reset read against zero if
 											// disabled.
@@ -417,7 +371,7 @@ public class DAViSFX3HardwareInterface extends CypressFX3Biasgen {
 									case 13: // APS Column End
 										CypressFX3.log.fine("APS Column End event received.");
 
-										if (apsCountY[apsCurrentReadoutType] != apsROISizeY[0]) {
+										if (apsCountY[apsCurrentReadoutType] != apsSizeY) {
 											CypressFX3.log.severe("APS Column End: wrong row count [" + apsCurrentReadoutType + " - "
 												+ apsCountY[apsCurrentReadoutType]
 												+ "] detected. You might want to enable 'Ensure APS data transfer' under 'HW Configuration -> Chip Configuration' to improve this.");
@@ -474,39 +428,21 @@ public class DAViSFX3HardwareInterface extends CypressFX3Biasgen {
 										break;
 
 									case 32:
-										// Next Misc8 APS ROI Size events will refer to ROI region 0.
-										// 0/1 used to distinguish between X and Y sizes.
-										apsROIUpdate = (0 << 2);
-										apsROISizeX[0] = apsROISizeY[0] = 0;
-										apsROIPositionX[0] = apsROIPositionY[0] = 0;
-										break;
-
 									case 33:
-										// Next Misc8 APS ROI Size events will refer to ROI region 1.
-										// 2/3 used to distinguish between X and Y sizes.
-										apsROIUpdate = (1 << 2);
-										apsROISizeX[1] = apsROISizeY[1] = 0;
-										apsROIPositionX[1] = apsROIPositionY[1] = 0;
-										break;
-
 									case 34:
-										// Next Misc8 APS ROI Size events will refer to ROI region 2.
-										// 4/5 used to distinguish between X and Y sizes.
-										apsROIUpdate = (2 << 2);
-										apsROISizeX[2] = apsROISizeY[2] = 0;
-										apsROIPositionX[2] = apsROIPositionY[2] = 0;
-										break;
-
 									case 35:
-										// Next Misc8 APS ROI Size events will refer to ROI region 3.
-										// 6/7 used to distinguish between X and Y sizes.
-										apsROIUpdate = (3 << 2);
-										apsROISizeX[3] = apsROISizeY[3] = 0;
-										apsROIPositionX[3] = apsROIPositionY[3] = 0;
+										// TODO: ROI OFF not exposed, so just ignore events.
 										break;
 
 									case 48:
 										// TODO: APS Exposure Information, ignore for now.
+										break;
+
+									case 49:
+									case 50:
+									case 51:
+									case 52:
+										// TODO: ROI ON not exposed, so just ignore events.
 										break;
 
 									default:
@@ -553,6 +489,7 @@ public class DAViSFX3HardwareInterface extends CypressFX3Biasgen {
 									// old logic, we have to flip it here, so that the chip class extractor
 									// can flip it back. Backwards compatibility with recordings is the main
 									// motivation to do this hack.
+									// NOTE 09.2017: logic now uses upper left (CG format) as output.
 
 									// Invert polarity for PixelParade high gain pixels (DavisSense), because of
 									// negative gain from pre-amplifier.
@@ -560,12 +497,12 @@ public class DAViSFX3HardwareInterface extends CypressFX3Biasgen {
 										? ((byte) (~code)) : (code);
 
 									if (dvsInvertXY) {
-										buffer.getAddresses()[eventCounter] = ((data << DavisChip.YSHIFT) & DavisChip.YMASK)
+										buffer.getAddresses()[eventCounter] = (((dvsSizeX - 1 - data) << DavisChip.YSHIFT) & DavisChip.YMASK)
 											| (((dvsSizeY - 1 - dvsLastY) << DavisChip.XSHIFT) & DavisChip.XMASK)
 											| (((polarity & 0x01) << DavisChip.POLSHIFT) & DavisChip.POLMASK);
 									}
 									else {
-										buffer.getAddresses()[eventCounter] = ((dvsLastY << DavisChip.YSHIFT) & DavisChip.YMASK)
+										buffer.getAddresses()[eventCounter] = (((dvsSizeY - 1 - dvsLastY) << DavisChip.YSHIFT) & DavisChip.YMASK)
 											| (((dvsSizeX - 1 - data) << DavisChip.XSHIFT) & DavisChip.XMASK)
 											| (((polarity & 0x01) << DavisChip.POLSHIFT) & DavisChip.POLMASK);
 									}
@@ -580,7 +517,7 @@ public class DAViSFX3HardwareInterface extends CypressFX3Biasgen {
 							case 4: // APS ADC sample
 								// Let's check that apsCountY is not above the maximum. This could happen
 								// if start/end of column events are discarded (no wait on transfer stall).
-								if (apsCountY[apsCurrentReadoutType] >= apsROISizeY[0]) {
+								if (apsCountY[apsCurrentReadoutType] >= apsSizeY) {
 									CypressFX3.log.fine("APS ADC sample: row count is at maximum, discarding further samples.");
 									break;
 								}
@@ -592,14 +529,14 @@ public class DAViSFX3HardwareInterface extends CypressFX3Biasgen {
 								int yPos;
 
 								if (apsFlipX) {
-									xPos = apsROISizeX[0] - 1 - apsCountX[apsCurrentReadoutType];
+									xPos = apsSizeX - 1 - apsCountX[apsCurrentReadoutType];
 								}
 								else {
 									xPos = apsCountX[apsCurrentReadoutType];
 								}
 
 								if (apsFlipY) {
-									yPos = apsROISizeY[0] - 1 - apsCountY[apsCurrentReadoutType];
+									yPos = apsSizeY - 1 - apsCountY[apsCurrentReadoutType];
 								}
 								else {
 									yPos = apsCountY[apsCurrentReadoutType];
@@ -723,51 +660,9 @@ public class DAViSFX3HardwareInterface extends CypressFX3Biasgen {
 										break;
 
 									case 1:
-										// APS ROI Size Part 1 (bits 15-8).
-										// Here we just store the temporary value, and use it again
-										// in the next case statement.
-										apsROITmpData = ((misc8Data & 0xFF) << 8);
-
+									case 2:
+										// Ignore ROI events.
 										break;
-
-									case 2: {
-										// APS ROI Size Part 2 (bits 7-0).
-										// Here we just store the values and re-use the four fields
-										// sizeX/Y and positionX/Y to store endCol/Row and startCol/Row.
-										// We then recalculate all the right values and set everything
-										// up in START_FRAME.
-										final short apsROIRegion = (short) (apsROIUpdate >> 2);
-
-										switch (apsROIUpdate & 0x03) {
-											case 0:
-												// START COLUMN
-												apsROIPositionX[apsROIRegion] = (short) (apsROITmpData | (misc8Data & 0xFF));
-												break;
-
-											case 1:
-												// START ROW
-												apsROIPositionY[apsROIRegion] = (short) (apsROITmpData | (misc8Data & 0xFF));
-												break;
-
-											case 2:
-												// END COLUMN
-												apsROISizeX[apsROIRegion] = (short) (apsROITmpData | (misc8Data & 0xFF));
-												break;
-
-											case 3:
-												// END ROW
-												apsROISizeY[apsROIRegion] = (short) (apsROITmpData | (misc8Data & 0xFF));
-												break;
-
-											default:
-												break;
-										}
-
-										// Jump to next type of APS info (col->row, start->end).
-										apsROIUpdate++;
-
-										break;
-									}
 
 									default:
 										CypressFX3.log.severe("Caught Misc8 event that can't be handled.");


### PR DESCRIPTION
Require new firmware v4 and logic v9912 for DAVIS cameras.
Origin changed on the device-side to upper left (CG format).
Removed unused ROI setting in jAER.
Fixed orientation of DAVIS128 and DAVIS208 cameras.