### PR TITLE
Fix USBAERmini2 configurationFix USBAERmini2 LibUsb configuration for DVS128 hardware interface

### DIFF
--- a/src/net/sf/jaer/hardwareinterface/usb/cypressfx2libusb/CypressFX2.java
+++ b/src/net/sf/jaer/hardwareinterface/usb/cypressfx2libusb/CypressFX2.java
@@ -10,6 +10,11 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeSupport;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.Preferences;
@@ -340,6 +345,10 @@ public class CypressFX2 implements AEMonitorInterface, ReaderBufferControl, USBI
     private String stringDescription = "CypressFX2"; // default which is
     // modified by opening
     private USBPacketStatistics usbPacketStatistics = new USBPacketStatistics();
+    private final Set<Byte> unsupportedVendorOutRequests = Collections.synchronizedSet(new HashSet<Byte>());
+    private final Set<Byte> unsupportedVendorInRequests = Collections.synchronizedSet(new HashSet<Byte>());
+    private final Set<Byte> loggedUnsupportedVendorOutRequests = Collections.synchronizedSet(new HashSet<Byte>());
+    private final Set<Byte> loggedUnsupportedVendorInRequests = Collections.synchronizedSet(new HashSet<Byte>());
 
     /**
      * Populates the device descriptor and the string descriptors and builds the
@@ -849,6 +858,10 @@ public class CypressFX2 implements AEMonitorInterface, ReaderBufferControl, USBI
 
         USBTransferThread usbTransfer;
         CypressFX2 monitor;
+        private final boolean usbaermini2RuntimeDebug = Boolean.getBoolean("jaer.usbaermini2.debug");
+        private int statusTransferErrorCount = 0;
+        private int statusTransferStallCount = 0;
+        private long firstStatusTransferStallEpochMs = -1;
 
         AsyncStatusThread(final CypressFX2 monitor) {
             this.monitor = monitor;
@@ -872,12 +885,45 @@ public class CypressFX2 implements AEMonitorInterface, ReaderBufferControl, USBI
         }
 
         public void stopThread() {
+            if (usbTransfer == null) {
+                return;
+            }
             usbTransfer.interrupt();
+
+            if (Thread.currentThread() == usbTransfer) {
+                CypressFX2.log.warning("AsyncStatusThread.stopThread called from AsyncStatusThread; skipping join to avoid deadlock");
+                return;
+            }
 
             try {
                 usbTransfer.join();
             } catch (final InterruptedException e) {
                 CypressFX2.log.severe("Failed to join AsyncStatusThread");
+            }
+        }
+
+        private boolean isUsbaermini2Device() {
+            return (monitor.getVID_THESYCON_FX2_CPLD() == (short) 0x0547) && (monitor.getPID() == CypressFX2.PID_USBAERmini2);
+        }
+
+        private String transferStatusName(final int status) {
+            switch (status) {
+                case LibUsb.TRANSFER_COMPLETED:
+                    return "TRANSFER_COMPLETED";
+                case LibUsb.TRANSFER_ERROR:
+                    return "TRANSFER_ERROR";
+                case LibUsb.TRANSFER_TIMED_OUT:
+                    return "TRANSFER_TIMED_OUT";
+                case LibUsb.TRANSFER_CANCELLED:
+                    return "TRANSFER_CANCELLED";
+                case LibUsb.TRANSFER_STALL:
+                    return "TRANSFER_STALL";
+                case LibUsb.TRANSFER_NO_DEVICE:
+                    return "TRANSFER_NO_DEVICE";
+                case LibUsb.TRANSFER_OVERFLOW:
+                    return "TRANSFER_OVERFLOW";
+                default:
+                    return "TRANSFER_STATUS_" + status;
             }
         }
 
@@ -892,8 +938,25 @@ public class CypressFX2 implements AEMonitorInterface, ReaderBufferControl, USBI
             public void processTransfer(final RestrictedTransfer transfer) {
                 if (transfer.status() != LibUsb.TRANSFER_COMPLETED) {
                     if (transfer.status() != LibUsb.TRANSFER_CANCELLED) {
-                        CypressFX2.log.warning("Error waiting for completion of read on status pipe: "
-                                + LibUsb.errorName(transfer.status()));
+                        statusTransferErrorCount++;
+                        if (transfer.status() == LibUsb.TRANSFER_STALL) {
+                            statusTransferStallCount++;
+                            if (firstStatusTransferStallEpochMs < 0) {
+                                firstStatusTransferStallEpochMs = System.currentTimeMillis();
+                            }
+                        }
+                        final String firstStallText = (firstStatusTransferStallEpochMs < 0)
+                                ? "none"
+                                : Instant.ofEpochMilli(firstStatusTransferStallEpochMs).toString();
+                        if (isUsbaermini2Device() || usbaermini2RuntimeDebug) {
+                            CypressFX2.log.warning(String.format(
+                                    "AsyncStatusThread transfer error: status=%s, bytes=%d, errors=%d, stalls=%d, firstStall=%s",
+                                    transferStatusName(transfer.status()), transfer.actualLength(), statusTransferErrorCount,
+                                    statusTransferStallCount, firstStallText));
+                        } else {
+                            CypressFX2.log.warning("Error waiting for completion of read on status pipe: "
+                                    + LibUsb.errorName(transfer.status()));
+                        }
                     }
 
                     return;
@@ -1008,6 +1071,20 @@ public class CypressFX2 implements AEMonitorInterface, ReaderBufferControl, USBI
 
         USBTransferThread usbTransfer;
         CypressFX2 monitor;
+        private final boolean usbaermini2RuntimeDebug = Boolean.getBoolean("jaer.usbaermini2.debug");
+        private long transferWindowStartNs = System.nanoTime();
+        private long transferWindowBytes = 0;
+        private int transferWindowCount = 0;
+        private int transferWindowCompleted = 0;
+        private int transferWindowErrors = 0;
+        private int transferWindowDecodedEvents = 0;
+        private int transferStallCount = 0;
+        private int transferErrorCount = 0;
+        private long firstStallEpochMs = -1;
+        private int consecutiveTransferErrors = 0;
+        private final AtomicBoolean recoveryInProgress = new AtomicBoolean(false);
+        private static final int MAX_CONSECUTIVE_TRANSFER_ERRORS_BEFORE_RECOVERY = 3;
+        private static final int MAX_TRANSFER_ERRORS_BEFORE_RECOVERY = 8;
 
         public AEReader(final CypressFX2 m) throws HardwareInterfaceException {
             monitor = m;
@@ -1026,11 +1103,20 @@ public class CypressFX2 implements AEMonitorInterface, ReaderBufferControl, USBI
             }
 
             CypressFX2.log.info("Starting AEReader");
+            resetTransferRuntimeStats();
             usbTransfer = new USBTransferThread(monitor.deviceHandle, (byte) 0x86, LibUsb.TRANSFER_TYPE_BULK,
                     new ProcessAEData(), getNumBuffers(), getFifoSize(), null, null, new Runnable() {
                 @Override
                 public void run() {
-                    monitor.close();
+                    // Keep close on a separate thread to avoid calling stop/join from inside USB callback context.
+                    final Thread closeThread = new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            monitor.close();
+                        }
+                    }, "CypressFX2-AEReaderClose-" + System.currentTimeMillis());
+                    closeThread.setDaemon(true);
+                    closeThread.start();
                 }
             });
             usbTransfer.setName("AEReaderThread");
@@ -1040,7 +1126,15 @@ public class CypressFX2 implements AEMonitorInterface, ReaderBufferControl, USBI
         }
 
         public void stopThread() {
+            if (usbTransfer == null) {
+                return;
+            }
             usbTransfer.interrupt();
+
+            if (Thread.currentThread() == usbTransfer) {
+                CypressFX2.log.warning("AEReader.stopThread called from AEReaderThread; skipping join to avoid deadlock");
+                return;
+            }
 
             try {
                 usbTransfer.join();
@@ -1086,6 +1180,137 @@ public class CypressFX2 implements AEMonitorInterface, ReaderBufferControl, USBI
             // are reset
         }
 
+        private boolean isUsbaermini2Device() {
+            return (monitor.getVID_THESYCON_FX2_CPLD() == (short) 0x0547) && (monitor.getPID() == CypressFX2.PID_USBAERmini2);
+        }
+
+        private String transferStatusName(final int status) {
+            switch (status) {
+                case LibUsb.TRANSFER_COMPLETED:
+                    return "TRANSFER_COMPLETED";
+                case LibUsb.TRANSFER_ERROR:
+                    return "TRANSFER_ERROR";
+                case LibUsb.TRANSFER_TIMED_OUT:
+                    return "TRANSFER_TIMED_OUT";
+                case LibUsb.TRANSFER_CANCELLED:
+                    return "TRANSFER_CANCELLED";
+                case LibUsb.TRANSFER_STALL:
+                    return "TRANSFER_STALL";
+                case LibUsb.TRANSFER_NO_DEVICE:
+                    return "TRANSFER_NO_DEVICE";
+                case LibUsb.TRANSFER_OVERFLOW:
+                    return "TRANSFER_OVERFLOW";
+                default:
+                    return "TRANSFER_STATUS_" + status;
+            }
+        }
+
+        private boolean isTransferErrorStatus(final int transferStatus) {
+            return (transferStatus != LibUsb.TRANSFER_COMPLETED) && (transferStatus != LibUsb.TRANSFER_CANCELLED);
+        }
+
+        private void resetTransferRuntimeStats() {
+            transferWindowStartNs = System.nanoTime();
+            transferWindowBytes = 0;
+            transferWindowCount = 0;
+            transferWindowCompleted = 0;
+            transferWindowErrors = 0;
+            transferWindowDecodedEvents = 0;
+            transferStallCount = 0;
+            transferErrorCount = 0;
+            firstStallEpochMs = -1;
+            consecutiveTransferErrors = 0;
+        }
+
+        private void updateTransferRuntimeStats(final int transferStatus, final int bytesTransferred, final int decodedEventsDelta) {
+            transferWindowCount++;
+            transferWindowBytes += bytesTransferred;
+            if (transferStatus == LibUsb.TRANSFER_COMPLETED) {
+                transferWindowCompleted++;
+            } else if (isTransferErrorStatus(transferStatus)) {
+                transferWindowErrors++;
+            }
+            if (decodedEventsDelta > 0) {
+                transferWindowDecodedEvents += decodedEventsDelta;
+            }
+
+            if (!isUsbaermini2Device() || !usbaermini2RuntimeDebug) {
+                return;
+            }
+
+            final long nowNs = System.nanoTime();
+            final long dtNs = nowNs - transferWindowStartNs;
+            if (dtNs < 1_000_000_000L) {
+                return;
+            }
+
+            final long bytesPerSecond = Math.round((transferWindowBytes * 1_000_000_000d) / dtNs);
+            final long eventsPerSecond = Math.round((transferWindowDecodedEvents * 1_000_000_000d) / dtNs);
+            final double avgTransferBytes = (transferWindowCount == 0) ? 0d : (transferWindowBytes / (double) transferWindowCount);
+            final String firstStallText = (firstStallEpochMs < 0)
+                    ? "none"
+                    : Instant.ofEpochMilli(firstStallEpochMs).toString();
+
+            CypressFX2.log.info(String.format(
+                    "USBAERmini2 runtime: eventsPerSec=%d, bytesPerSec=%d, transfers=%d, completed=%d, errors=%d, avgBytesPerTransfer=%.1f, stalls=%d, firstStall=%s",
+                    eventsPerSecond, bytesPerSecond, transferWindowCount, transferWindowCompleted, transferWindowErrors,
+                    avgTransferBytes, transferStallCount, firstStallText));
+
+            transferWindowStartNs = nowNs;
+            transferWindowBytes = 0;
+            transferWindowCount = 0;
+            transferWindowCompleted = 0;
+            transferWindowErrors = 0;
+            transferWindowDecodedEvents = 0;
+        }
+
+        private boolean tryClearInEndpointHalt() {
+            if (monitor.deviceHandle == null) {
+                return false;
+            }
+            final int clearStatus = LibUsb.clearHalt(monitor.deviceHandle, CypressFX2.AE_MONITOR_ENDPOINT_ADDRESS);
+            if (clearStatus == LibUsb.SUCCESS) {
+                CypressFX2.log.warning(String.format(
+                        "AEReader transfer recovery: cleared HALT on endpoint 0x%02X, will continue streaming",
+                        CypressFX2.AE_MONITOR_ENDPOINT_ADDRESS & 0xFF));
+                try {
+                    monitor.requestEarlyTransfer();
+                } catch (final HardwareInterfaceException e) {
+                    CypressFX2.log.warning("AEReader transfer recovery: requestEarlyTransfer after clearHalt failed: " + e.toString());
+                }
+                return true;
+            }
+            CypressFX2.log.warning(String.format(
+                    "AEReader transfer recovery: clearHalt failed on endpoint 0x%02X with %s",
+                    CypressFX2.AE_MONITOR_ENDPOINT_ADDRESS & 0xFF, LibUsb.errorName(clearStatus)));
+            return false;
+        }
+
+        private void scheduleRecoveryAfterTransferError(final String reason) {
+            if (!recoveryInProgress.compareAndSet(false, true)) {
+                return;
+            }
+            final Thread recoveryThread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        CypressFX2.log.warning("AEReader transfer recovery: starting device reopen sequence, reason=" + reason);
+                        monitor.close();
+                        monitor.open();
+                        monitor.setEventAcquisitionEnabled(true);
+                        CypressFX2.log.warning("AEReader transfer recovery: device reopen sequence completed");
+                        consecutiveTransferErrors = 0;
+                    } catch (final Exception e) {
+                        CypressFX2.log.severe("AEReader transfer recovery failed: " + e.toString());
+                    } finally {
+                        recoveryInProgress.set(false);
+                    }
+                }
+            }, "CypressFX2-Recovery-" + System.currentTimeMillis());
+            recoveryThread.setDaemon(true);
+            recoveryThread.start();
+        }
+
         class ProcessAEData implements RestrictedTransferCallback {
 
             @Override
@@ -1101,13 +1326,24 @@ public class CypressFX2 implements AEMonitorInterface, ReaderBufferControl, USBI
              */
             @Override
             public void processTransfer(final RestrictedTransfer transfer) {
+                final int transferStatus = transfer.status();
+                final int bytesTransferred = transfer.actualLength();
+                int decodedEventsDelta = 0;
                 cycleCounter++;
                 usbPacketStatistics.addSample(transfer);
 
                 synchronized (aePacketRawPool) {
-                    if ((transfer.status() == LibUsb.TRANSFER_COMPLETED)
-                            || (transfer.status() == LibUsb.TRANSFER_CANCELLED)) {
+                    if ((transferStatus == LibUsb.TRANSFER_COMPLETED)
+                            || (transferStatus == LibUsb.TRANSFER_CANCELLED)) {
+                        final int eventCounterBefore = eventCounter;
                         translateEvents(transfer.buffer());
+                        decodedEventsDelta = eventCounter - eventCounterBefore;
+                        if (decodedEventsDelta < 0) {
+                            decodedEventsDelta = 0;
+                        }
+                        if (transferStatus == LibUsb.TRANSFER_COMPLETED) {
+                            consecutiveTransferErrors = 0;
+                        }
 
                         if ((chip != null) && (chip.getFilterChain() != null)
                                 && (chip.getFilterChain().getProcessingMode() == FilterChain.ProcessingMode.ACQUISITION)) {
@@ -1128,8 +1364,47 @@ public class CypressFX2 implements AEMonitorInterface, ReaderBufferControl, USBI
                             realTimeFilter(addresses, timestamps);
                         }
                     } else {
-                        CypressFX2.log.warning("ProcessAEData: Bytes transferred: " + transfer.actualLength()
-                                + "  Status: " + LibUsb.errorName(transfer.status()));
+                        if (isUsbaermini2Device()) {
+                            transferErrorCount++;
+                            consecutiveTransferErrors++;
+                            if (transferStatus == LibUsb.TRANSFER_STALL) {
+                                transferStallCount++;
+                                if (firstStallEpochMs < 0) {
+                                    firstStallEpochMs = System.currentTimeMillis();
+                                }
+                            }
+
+                            final String firstStallText = (firstStallEpochMs < 0)
+                                    ? "none"
+                                    : Instant.ofEpochMilli(firstStallEpochMs).toString();
+                            CypressFX2.log.warning(String.format(
+                                    "ProcessAEData transfer error: status=%s, bytes=%d, errors=%d, stalls=%d, consecutive=%d, firstStall=%s",
+                                    transferStatusName(transferStatus), bytesTransferred, transferErrorCount, transferStallCount,
+                                    consecutiveTransferErrors, firstStallText));
+
+                            boolean recoveredByClearHalt = false;
+                            if ((transferStatus == LibUsb.TRANSFER_STALL) || (transferStatus == LibUsb.TRANSFER_ERROR)
+                                    || (transferStatus == LibUsb.TRANSFER_OVERFLOW)) {
+                                recoveredByClearHalt = tryClearInEndpointHalt();
+                                if (recoveredByClearHalt) {
+                                    consecutiveTransferErrors = 0;
+                                }
+                            }
+
+                            final boolean shouldReopen = !recoveredByClearHalt
+                                    && ((consecutiveTransferErrors >= MAX_CONSECUTIVE_TRANSFER_ERRORS_BEFORE_RECOVERY)
+                                            || (transferErrorCount >= MAX_TRANSFER_ERRORS_BEFORE_RECOVERY)
+                                            || (transferStatus == LibUsb.TRANSFER_NO_DEVICE));
+                            if (shouldReopen) {
+                                scheduleRecoveryAfterTransferError(String.format(
+                                        "status=%s, bytes=%d, errors=%d, stalls=%d, consecutive=%d",
+                                        transferStatusName(transferStatus), bytesTransferred, transferErrorCount,
+                                        transferStallCount, consecutiveTransferErrors));
+                            }
+                        } else {
+                            CypressFX2.log.warning("ProcessAEData: Bytes transferred: " + bytesTransferred
+                                    + "  Status: " + LibUsb.errorName(transferStatus));
+                        }
                     }
 
                     if (timestampsReset) {
@@ -1138,6 +1413,8 @@ public class CypressFX2 implements AEMonitorInterface, ReaderBufferControl, USBI
                         timestampsReset = false;
                     }
                 }
+
+                updateTransferRuntimeStats(transferStatus, bytesTransferred, decodedEventsDelta);
             }
         }
 
@@ -1749,6 +2026,45 @@ public class CypressFX2 implements AEMonitorInterface, ReaderBufferControl, USBI
         return lastEventsAcquired;
     }
 
+    private short safeDid() {
+        if (deviceDescriptor == null) {
+            return 0;
+        }
+        return deviceDescriptor.bcdDevice();
+    }
+
+    private String requestToHex(final byte request) {
+        return String.format("0x%02X", request & 0xFF);
+    }
+
+    private boolean isVendorOutRequestUnsupported(final byte request) {
+        return unsupportedVendorOutRequests.contains(Byte.valueOf(request));
+    }
+
+    private boolean isVendorInRequestUnsupported(final byte request) {
+        return unsupportedVendorInRequests.contains(Byte.valueOf(request));
+    }
+
+    private void markVendorOutRequestUnsupported(final byte request) {
+        final Byte req = Byte.valueOf(request);
+        unsupportedVendorOutRequests.add(req);
+        if (loggedUnsupportedVendorOutRequests.add(req)) {
+            CypressFX2.log.warning(String.format(
+                    "Marking vendor OUT request %s unsupported for DID=0x%04X after LIBUSB_ERROR_PIPE; future attempts will be skipped",
+                    requestToHex(request), safeDid() & 0xFFFF));
+        }
+    }
+
+    private void markVendorInRequestUnsupported(final byte request) {
+        final Byte req = Byte.valueOf(request);
+        unsupportedVendorInRequests.add(req);
+        if (loggedUnsupportedVendorInRequests.add(req)) {
+            CypressFX2.log.warning(String.format(
+                    "Marking vendor IN request %s unsupported for DID=0x%04X after LIBUSB_ERROR_PIPE; future attempts will not be retried",
+                    requestToHex(request), safeDid() & 0xFFFF));
+        }
+    }
+
     /**
      * Sends a vendor request without any data packet, value and index are set
      * to zero. This is a blocking method.
@@ -1828,6 +2144,14 @@ public class CypressFX2 implements AEMonitorInterface, ReaderBufferControl, USBI
         if (!isOpen()) {
             open();
         }
+        if (isVendorOutRequestUnsupported(request)) {
+            if (loggedUnsupportedVendorOutRequests.add(Byte.valueOf(request))) {
+                CypressFX2.log.warning(String.format(
+                        "Skipping previously unsupported vendor OUT request %s for DID=0x%04X",
+                        requestToHex(request), safeDid() & 0xFFFF));
+            }
+            return;
+        }
 
         if (dataBuffer == null) {
             dataBuffer = BufferUtils.allocateByteBuffer(0);
@@ -1837,6 +2161,9 @@ public class CypressFX2 implements AEMonitorInterface, ReaderBufferControl, USBI
 
         final int status = LibUsb.controlTransfer(deviceHandle, bmRequestType, request, value, index, dataBuffer, 0);
         if (status < LibUsb.SUCCESS) {
+            if (status == LibUsb.ERROR_PIPE) {
+                markVendorOutRequestUnsupported(request);
+            }
             throw new HardwareInterfaceException("Unable to send vendor OUT request " + String.format("0x%x", request)
                     + ": " + LibUsb.errorName(status));
         }
@@ -1868,6 +2195,11 @@ public class CypressFX2 implements AEMonitorInterface, ReaderBufferControl, USBI
         if (!isOpen()) {
             open();
         }
+        if (isVendorInRequestUnsupported(request)) {
+            throw new HardwareInterfaceException(String.format(
+                    "Vendor IN request %s previously marked unsupported for DID=0x%04X due to LIBUSB_ERROR_PIPE",
+                    requestToHex(request), safeDid() & 0xFFFF));
+        }
 
         final ByteBuffer dataBuffer = BufferUtils.allocateByteBuffer(dataLength);
 
@@ -1875,6 +2207,9 @@ public class CypressFX2 implements AEMonitorInterface, ReaderBufferControl, USBI
 
         final int status = LibUsb.controlTransfer(deviceHandle, bmRequestType, request, value, index, dataBuffer, 0);
         if (status < LibUsb.SUCCESS) {
+            if (status == LibUsb.ERROR_PIPE) {
+                markVendorInRequestUnsupported(request);
+            }
             throw new HardwareInterfaceException("Unable to send vendor IN request " + String.format("0x%x", request)
                     + ": " + LibUsb.errorName(status));
         }

--- a/src/net/sf/jaer/hardwareinterface/usb/cypressfx2libusb/CypressFX2LibUsbDVS128HardwareInterface.java
+++ b/src/net/sf/jaer/hardwareinterface/usb/cypressfx2libusb/CypressFX2LibUsbDVS128HardwareInterface.java
@@ -32,9 +32,32 @@ import org.usb4java.Device;
 public class CypressFX2LibUsbDVS128HardwareInterface extends CypressFX2Biasgen implements CypressFX2DVS128HardwareInterfaceInterface {
 
     protected static Preferences prefs = JaerConstants.PREFS_ROOT_HARDWARE;
+    private static final String SYNC_EVENT_PREF_KEY = "CypressFX2DVS128HardwareInterface.syncEventEnabled";
+    private static final String DEBUG_WORD_DUMP_PROPERTY = "jaer.usbaermini2.debug";
+    private static final String DEBUG_WORD_DUMP_LIMIT_PROPERTY = "jaer.usbaermini2.debugWords";
+    private static final int DEFAULT_DEBUG_WORD_DUMP_LIMIT = 64;
+    private static final int PROFILE_BOOTSTRAP_WORDS = 1024;
+    private static final short USBAERMINI2_VID = (short) 0x0547;
+    private static final byte VENDOR_REQUEST_OPERATION_MODE = (byte) 0xC3;
     private boolean syncEventEnabled = CypressFX2LibUsbDVS128HardwareInterface.prefs.getBoolean(
-            "CypressFX2DVS128HardwareInterface.syncEventEnabled", true); // default
+            SYNC_EVENT_PREF_KEY, true); // default
     //  is true so that device is the timestamp master by default, necessary after firmware rev 11
+    private boolean disableSyncVendorRequest = false;
+    private boolean isUsbaermini2 = false;
+    private short usbaermini2Did = 0;
+    private volatile boolean usbaermini2TimestampValidated = false;
+    private volatile boolean usbaermini2TimestampHealthWindowEvaluated = false;
+
+    /**
+     * USBAERmini2 decode/timestamp behavior ported from SensorsINI/jaer 20180323
+     * (CypressFX2MonitorSequencer): DID-based parser split and startup timestamp init.
+     */
+    private enum DecodeProfile {
+        CPLD_LE,
+        ORIGINAL_LE,
+        CPLD_BE,
+        ORIGINAL_BE
+    }
 
     /**
      * Vendor request for setting LED
@@ -55,6 +78,32 @@ public class CypressFX2LibUsbDVS128HardwareInterface extends CypressFX2Biasgen i
     @Override
     public synchronized void open() throws HardwareInterfaceException {
         super.open();
+        isUsbaermini2 = (getVID_THESYCON_FX2_CPLD() == USBAERMINI2_VID) && (getPID() == CypressFX2.PID_USBAERmini2);
+        usbaermini2Did = isUsbaermini2 ? getDID() : 0;
+        usbaermini2TimestampValidated = false;
+        usbaermini2TimestampHealthWindowEvaluated = false;
+
+        if (isUsbaermini2) {
+            CypressFX2.log.info(String.format(
+                    "USBAERmini2 detected (VID/PID 0x%04X/0x%04X, DID=0x%04X)",
+                    (getVID_THESYCON_FX2_CPLD() & 0xFFFF), (getPID() & 0xFFFF), (usbaermini2Did & 0xFFFF)));
+            // Startup timestamp init sequence for USBAERmini2 firmware, independent of sync-event requests.
+            try {
+                sendVendorRequest(VENDOR_REQUEST_OPERATION_MODE, (short) 0, (short) 0); // host/master, 1us tick
+            } catch (final HardwareInterfaceException e) {
+                CypressFX2.log.warning("USBAERmini2 operation-mode init request failed: " + e.toString());
+            }
+            try {
+                sendVendorRequest(VENDOR_REQUEST_RESET_TIMESTAMPS, (short) 0, (short) 0); // one-time startup reset
+            } catch (final HardwareInterfaceException e) {
+                CypressFX2.log.warning("USBAERmini2 startup timestamp reset request failed: " + e.toString());
+            }
+            if (syncEventEnabled) {
+                CypressFX2.log.info("USBAERmini2 detected: defaulting sync-event generation to disabled");
+                syncEventEnabled = false;
+                CypressFX2LibUsbDVS128HardwareInterface.prefs.putBoolean(SYNC_EVENT_PREF_KEY, false);
+            }
+        }
         setSyncEventEnabled(syncEventEnabled);
     }
 
@@ -89,20 +138,50 @@ public class CypressFX2LibUsbDVS128HardwareInterface extends CypressFX2Biasgen i
     @Override
     public void setSyncEventEnabled(final boolean yes) {
         CypressFX2.log.info("setting " + yes);
+        if ((getPID() == CypressFX2.PID_USBAERmini2) && !yes) {
+            // Many USBAERmini2 firmwares don't support vendor request 0xBE.
+            // Keep local state disabled and avoid sending the request.
+            syncEventEnabled = false;
+            CypressFX2LibUsbDVS128HardwareInterface.prefs.putBoolean(SYNC_EVENT_PREF_KEY, false);
+            return;
+        }
+        if (disableSyncVendorRequest && (getPID() == CypressFX2.PID_USBAERmini2)) {
+            syncEventEnabled = false;
+            CypressFX2LibUsbDVS128HardwareInterface.prefs.putBoolean(SYNC_EVENT_PREF_KEY, false);
+            return;
+        }
 
         try {
             this.sendVendorRequest(VENDOR_REQUEST_SET_SYNC_ENABLED, yes ? (byte) 1 : (byte) 0, (byte) 0);
             syncEventEnabled = yes;
-            CypressFX2LibUsbDVS128HardwareInterface.prefs.putBoolean("CypressFX2DVS128HardwareInterface.syncEventEnabled",
+            CypressFX2LibUsbDVS128HardwareInterface.prefs.putBoolean(SYNC_EVENT_PREF_KEY,
                     yes);
         } catch (final HardwareInterfaceException e) {
-            CypressFX2.log.warning(e.toString());
+            CypressFX2.log.warning(e.toString()
+                    + "; forcing syncEventEnabled=false so acquisition can continue");
+            syncEventEnabled = false;
+            CypressFX2LibUsbDVS128HardwareInterface.prefs.putBoolean(SYNC_EVENT_PREF_KEY, false);
+            if (getPID() == CypressFX2.PID_USBAERmini2) {
+                disableSyncVendorRequest = true;
+            }
         }
     }
 
     @Override
     public boolean isSyncEventEnabled() {
         return syncEventEnabled;
+    }
+
+    public boolean isUsbaermini2Device() {
+        return isUsbaermini2;
+    }
+
+    public boolean isUsbaermini2TimestampValidated() {
+        return usbaermini2TimestampValidated;
+    }
+
+    public boolean hasUsbaermini2TimestampHealthWindowEvaluated() {
+        return usbaermini2TimestampHealthWindowEvaluated;
     }
 
     int lastTimestampTmp = 0; // TODO debug remove
@@ -174,10 +253,54 @@ public class CypressFX2LibUsbDVS128HardwareInterface extends CypressFX2Biasgen i
      */
     public class RetinaAEReader extends CypressFX2.AEReader {
 
+        private static final int WORD_EVENT = 0;
+        private static final int WORD_WRAP = 1;
+        private static final int WORD_RESET = 2;
+        private static final long BOOTSTRAP_MAX_WAIT_NS = 2_000_000_000L;
+        private static final int TIMESTAMP_HEALTH_MIN_EVENTS = 4096;
+        private static final double TIMESTAMP_HEALTH_MAX_NONMONOTONIC_RATIO = 0.01d;
+        private static final long TIMESTAMP_DIAGNOSTIC_LOG_INTERVAL_NS = 5_000_000_000L;
         private int printedSyncEventWarningCount = 0; // only print this many sync events
         private int resetTimestampWarningCount = 0;
         private final int RESET_TIMESTAMPS_INITIAL_PRINTING_LIMIT = 10;
         private final int RESET_TIMESTAMPS_WARNING_INTERVAL = 100000;
+        private final boolean debugWordDumpEnabled = Boolean.getBoolean(DEBUG_WORD_DUMP_PROPERTY);
+        private final int debugWordDumpLimit = Math.max(0, Integer.getInteger(DEBUG_WORD_DUMP_LIMIT_PROPERTY, DEFAULT_DEBUG_WORD_DUMP_LIMIT));
+        private int debugWordDumpCount = 0;
+        private DecodeProfile decodeProfile = DecodeProfile.CPLD_LE;
+        private boolean decodeProfileLocked = true;
+        private int bootstrapWordCount = 0;
+        private final int[] bootstrapRawWords = new int[PROFILE_BOOTSTRAP_WORDS];
+        private long bootstrapStartNs = 0;
+        private long rateWindowStartNs = System.nanoTime();
+        private int rateWindowDecodedEvents = 0;
+        private long timestampWindowDecodedEvents = 0;
+        private long timestampWindowNonMonotonicCount = 0;
+        private int timestampWindowMin = Integer.MAX_VALUE;
+        private int timestampWindowMax = Integer.MIN_VALUE;
+        private long timestampDecodedEventsTotal = 0;
+        private long timestampNonMonotonicTotal = 0;
+        private int timestampMinTotal = Integer.MAX_VALUE;
+        private int timestampMaxTotal = Integer.MIN_VALUE;
+        private long timestampDiagnosticLastLogNs = System.nanoTime();
+        private boolean timestampStreamHealthy = false;
+
+        private final class DecodeQuality {
+
+            private final DecodeProfile profile;
+            private int eventCount = 0;
+            private int resetCount = 0;
+            private int wrapCount = 0;
+            private int nonMonotonicCount = 0;
+
+            private DecodeQuality(final DecodeProfile profile) {
+                this.profile = profile;
+            }
+
+            private double resetRatio(final int totalWords) {
+                return (totalWords <= 0) ? 0d : (resetCount / (double) totalWords);
+            }
+        }
 
         /**
          * Constructs a new reader for the interface.
@@ -187,6 +310,106 @@ public class CypressFX2LibUsbDVS128HardwareInterface extends CypressFX2Biasgen i
          */
         public RetinaAEReader(final CypressFX2 cypress) throws HardwareInterfaceException {
             super(cypress);
+            if (isUsbaermini2) {
+                // Ported from 20180323 CypressFX2MonitorSequencer:
+                // DID>0 uses CPLD code path (bit14 reset marker), older firmware does not.
+                decodeProfile = (usbaermini2Did > 0) ? DecodeProfile.CPLD_LE : DecodeProfile.ORIGINAL_LE;
+                decodeProfileLocked = false;
+                bootstrapStartNs = System.nanoTime();
+                CypressFX2.log.info(String.format(
+                        "USBAERmini2 decode bootstrap enabled: initial profile=%s, DID=0x%04X",
+                        decodeProfile, (usbaermini2Did & 0xFFFF)));
+            }
+        }
+
+        @Override
+        synchronized public void resetTimestamps() {
+            if (isUsbaermini2 && shouldSuppressLegacyTimestampWarning()) {
+                // During USBAERmini2 bootstrap/validation, or once validated, keep local reset silent.
+                wrapAdd = WRAP_START;
+                timestampsReset = true;
+                return;
+            }
+            super.resetTimestamps();
+        }
+
+        private boolean shouldSuppressLegacyTimestampWarning() {
+            if (!isUsbaermini2) {
+                return false;
+            }
+            if (CypressFX2LibUsbDVS128HardwareInterface.this.usbaermini2TimestampValidated || timestampStreamHealthy) {
+                return true;
+            }
+            // Suppress legacy warning until first timestamp-health window is evaluated.
+            return !CypressFX2LibUsbDVS128HardwareInterface.this.usbaermini2TimestampHealthWindowEvaluated;
+        }
+
+        private void updateTimestampHealth(final int timestamp, final boolean nonMonotonic) {
+            if (!isUsbaermini2) {
+                return;
+            }
+            timestampDecodedEventsTotal++;
+            timestampWindowDecodedEvents++;
+
+            if (nonMonotonic) {
+                timestampNonMonotonicTotal++;
+                timestampWindowNonMonotonicCount++;
+            }
+
+            if (timestamp < timestampMinTotal) {
+                timestampMinTotal = timestamp;
+            }
+            if (timestamp > timestampMaxTotal) {
+                timestampMaxTotal = timestamp;
+            }
+            if (timestamp < timestampWindowMin) {
+                timestampWindowMin = timestamp;
+            }
+            if (timestamp > timestampWindowMax) {
+                timestampWindowMax = timestamp;
+            }
+
+            maybeUpdateTimestampHealthWindow();
+            maybeLogTimestampDiagnostics();
+        }
+
+        private void maybeUpdateTimestampHealthWindow() {
+            if (timestampWindowDecodedEvents < TIMESTAMP_HEALTH_MIN_EVENTS) {
+                return;
+            }
+            CypressFX2LibUsbDVS128HardwareInterface.this.usbaermini2TimestampHealthWindowEvaluated = true;
+            final double nonMonotonicRatio = timestampWindowNonMonotonicCount / (double) timestampWindowDecodedEvents;
+            timestampStreamHealthy = (timestampWindowDecodedEvents > 0) && (timestampWindowMax > timestampWindowMin)
+                    && (nonMonotonicRatio < TIMESTAMP_HEALTH_MAX_NONMONOTONIC_RATIO);
+            if (timestampStreamHealthy && !CypressFX2LibUsbDVS128HardwareInterface.this.usbaermini2TimestampValidated) {
+                CypressFX2LibUsbDVS128HardwareInterface.this.usbaermini2TimestampValidated = true;
+                CypressFX2.log.info(String.format(
+                        "USBAERmini2 timestamp stream validated: profile=%s, decodedEvents=%d, nonMonotonic=%d, minTs=%d, maxTs=%d, ratio=%.6f",
+                        decodeProfile, timestampWindowDecodedEvents, timestampWindowNonMonotonicCount,
+                        timestampWindowMin, timestampWindowMax, nonMonotonicRatio));
+            }
+            timestampWindowDecodedEvents = 0;
+            timestampWindowNonMonotonicCount = 0;
+            timestampWindowMin = Integer.MAX_VALUE;
+            timestampWindowMax = Integer.MIN_VALUE;
+        }
+
+        private void maybeLogTimestampDiagnostics() {
+            if (!isUsbaermini2) {
+                return;
+            }
+            final long nowNs = System.nanoTime();
+            if ((nowNs - timestampDiagnosticLastLogNs) < TIMESTAMP_DIAGNOSTIC_LOG_INTERVAL_NS) {
+                return;
+            }
+            final int minTs = (timestampMinTotal == Integer.MAX_VALUE) ? 0 : timestampMinTotal;
+            final int maxTs = (timestampMaxTotal == Integer.MIN_VALUE) ? 0 : timestampMaxTotal;
+            final long dtSpan = Math.max(0L, (long) maxTs - minTs);
+            CypressFX2.log.info(String.format(
+                    "USBAERmini2 timestamp diagnostics: profile=%s, decodedEvents=%d, nonMonotonic=%d, timestampMin=%d, timestampMax=%d, dtSpanUs=%d, healthy=%s, validated=%s",
+                    decodeProfile, timestampDecodedEventsTotal, timestampNonMonotonicTotal, minTs, maxTs, dtSpan,
+                    timestampStreamHealthy, CypressFX2LibUsbDVS128HardwareInterface.this.usbaermini2TimestampValidated));
+            timestampDiagnosticLastLogNs = nowNs;
         }
 
         /**
@@ -199,7 +422,6 @@ public class CypressFX2LibUsbDVS128HardwareInterface extends CypressFX2Biasgen i
         protected void translateEvents(final ByteBuffer b) {
             synchronized (aePacketRawPool) {
                 final AEPacketRaw buffer = aePacketRawPool.writeBuffer();
-                int shortts;
 
                 int bytesSent = b.limit();
 
@@ -216,74 +438,27 @@ public class CypressFX2LibUsbDVS128HardwareInterface extends CypressFX2Biasgen i
                 buffer.lastCaptureIndex = eventCounter;
 
                 for (int i = 0; i < bytesSent; i += 4) {
-                    // if(eventCounter>aeBufferSize-1){
-                    // buffer.overrunOccuredFlag=true;
-                    // // log.warning("overrun");
-                    // return; // return, output event buffer is full and we cannot add any more events to it.
-                    // //no more events will be translated until the existing events have been consumed by
-                    // acquireAvailableEventsFromDriver
-                    // }
-
-                    if ((b.get(i + 3) & 0x80) == 0x80) { // timestamp bit 15 is one -> wrap
-                        // now we need to increment the wrapAdd
-
-                        wrapAdd += 0x4000L; // uses only 14 bit timestamps
-
-                        // System.out.println("received wrap event, index:" + eventCounter + " wrapAdd: "+ wrapAdd);
-                        // NumberOfWrapEvents++;
-                    } else if ((b.get(i + 3) & 0x40) == 0x40) { // timestamp bit 14 is one -> wrapAdd reset
-                        // this firmware version uses reset events to reset timestamps
-                        resetTimestamps();
-                        lastTimestampTmp = 0; // Also reset this one to avoid spurious warnings.
-                        if ((resetTimestampWarningCount < RESET_TIMESTAMPS_INITIAL_PRINTING_LIMIT)
-                                || ((resetTimestampWarningCount % RESET_TIMESTAMPS_WARNING_INTERVAL) == 0)) {
-                            CypressFX2.log.info(this + ".translateEvents got reset event from hardware, timestamp "
-                                    + (0xffff & ((b.get(i + 2) & 0xff) | ((b.get(i + 3) & 0x3f) << 8))));
+                    final int b0 = b.get(i) & 0xFF;
+                    final int b1 = b.get(i + 1) & 0xFF;
+                    final int b2 = b.get(i + 2) & 0xFF;
+                    final int b3 = b.get(i + 3) & 0xFF;
+                    final int rawWord = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
+                    if (isUsbaermini2 && !decodeProfileLocked) {
+                        if (bootstrapWordCount < PROFILE_BOOTSTRAP_WORDS) {
+                            bootstrapRawWords[bootstrapWordCount++] = rawWord;
                         }
-                        if (resetTimestampWarningCount == RESET_TIMESTAMPS_INITIAL_PRINTING_LIMIT) {
-                            CypressFX2.log
-                                    .warning("will only print reset timestamps message every "
-                                            + RESET_TIMESTAMPS_WARNING_INTERVAL
-                                            + " times now\nCould it be that you are trying to inject sync events using the DVS128 IN pin?\nIf so, select the \"Enable sync events output\" option in the DVS128 menu");
+                        if (shouldFinalizeBootstrap()) {
+                            finalizeBootstrapAndDecode(buffer, addresses, timestamps);
                         }
-                        resetTimestampWarningCount++;
-                    } else if ((eventCounter > (aeBufferSize - 1)) || (buffer.overrunOccuredFlag)) { // just do nothing,
-                        // throw away events
-                        buffer.overrunOccuredFlag = true;
-                    } else {
-                        // address is LSB MSB
-                        addresses[eventCounter] = (b.get(i) & 0xFF) | ((b.get(i + 1) & 0xFF) << 8);
-
-                        // same for timestamp, LSB MSB
-                        shortts = ((b.get(i + 2) & 0xff) | ((b.get(i + 3) & 0xff) << 8)); // this is 15 bit value
-                        // of timestamp in
-                        // TICK_US tick
-
-                        timestamps[eventCounter] = TICK_US * (shortts + wrapAdd); // *TICK_US; //add in the wrap offset
-                        // and convert to 1us tick
-
-                        if (timestamps[eventCounter] < lastTimestampTmp) {
-                            CypressFX2.log.info(String.format("nonmonotonic timestamp: lastTimestamp=%,d, timestamp=%,d, dt=%,d",
-                                    lastTimestampTmp,
-                                    timestamps[eventCounter],
-                                    (lastTimestampTmp - timestamps[eventCounter])));
-                        }
-                        lastTimestampTmp = timestamps[eventCounter];
-                        // this is USB2AERmini2 or StereoRetina board which have 1us timestamp tick
-                        if ((addresses[eventCounter] & CypressFX2LibUsbDVS128HardwareInterface.SYNC_EVENT_BITMASK) != 0) {
-                            if (printedSyncEventWarningCount < 10) {
-                                if (printedSyncEventWarningCount < 10) {
-                                    CypressFX2.log.info("sync event at timestamp=" + timestamps[eventCounter]);
-                                } else {
-                                    CypressFX2.log.warning("disabling further printing of sync events");
-                                }
-                                printedSyncEventWarningCount++;
-                            }
-                        }
-                        eventCounter++;
-                        buffer.setNumEvents(eventCounter);
+                        continue;
                     }
+                    final DecodeProfile activeProfile = isUsbaermini2 ? decodeProfile : DecodeProfile.CPLD_LE;
+                    processWord(rawWord, b0, b1, b2, b3, activeProfile, buffer, addresses, timestamps);
                 } // end for
+
+                if (isUsbaermini2 && !decodeProfileLocked && shouldFinalizeBootstrap()) {
+                    finalizeBootstrapAndDecode(buffer, addresses, timestamps);
+                }
 
                 // write capture size
                 buffer.lastCaptureLength = eventCounter - buffer.lastCaptureIndex;
@@ -295,6 +470,264 @@ public class CypressFX2LibUsbDVS128HardwareInterface extends CypressFX2Biasgen i
                 // System.out.println("wrapAdd : "+ wrapAdd);
             } // sync on aePacketRawPool
 
+        }
+
+        private boolean shouldFinalizeBootstrap() {
+            if (decodeProfileLocked) {
+                return false;
+            }
+            if (bootstrapWordCount >= PROFILE_BOOTSTRAP_WORDS) {
+                return true;
+            }
+            if (bootstrapWordCount < 64) {
+                return false;
+            }
+            return (System.nanoTime() - bootstrapStartNs) >= BOOTSTRAP_MAX_WAIT_NS;
+        }
+
+        private void finalizeBootstrapAndDecode(final AEPacketRaw buffer, final int[] addresses, final int[] timestamps) {
+            if (decodeProfileLocked || (bootstrapWordCount == 0)) {
+                decodeProfileLocked = true;
+                return;
+            }
+
+            final DecodeQuality activeQuality = evaluateDecodeQuality(decodeProfile, bootstrapWordCount);
+            if ((activeQuality.resetRatio(bootstrapWordCount) > 0.90d) || (activeQuality.eventCount == 0)) {
+                final DecodeQuality bestQuality = chooseBestProfile(bootstrapWordCount);
+                if (bestQuality.profile != decodeProfile) {
+                    CypressFX2.log.warning(String.format(
+                            "USBAERmini2 bootstrap detected implausible decode with profile %s "
+                            + "(resets=%d/%d, events=%d). Switching to %s (events=%d, resets=%d, nonMonotonic=%d).",
+                            decodeProfile, activeQuality.resetCount, bootstrapWordCount, activeQuality.eventCount,
+                            bestQuality.profile, bestQuality.eventCount, bestQuality.resetCount, bestQuality.nonMonotonicCount));
+                    decodeProfile = bestQuality.profile;
+                }
+            }
+            decodeProfileLocked = true;
+            if (debugWordDumpEnabled) {
+                CypressFX2.log.info(String.format(
+                        "USBAERmini2 decode bootstrap finalized with profile %s after %d words",
+                        decodeProfile, bootstrapWordCount));
+            }
+
+            for (int idx = 0; idx < bootstrapWordCount; idx++) {
+                final int rawWord = bootstrapRawWords[idx];
+                final int b0 = rawWord & 0xFF;
+                final int b1 = (rawWord >>> 8) & 0xFF;
+                final int b2 = (rawWord >>> 16) & 0xFF;
+                final int b3 = (rawWord >>> 24) & 0xFF;
+                processWord(rawWord, b0, b1, b2, b3, decodeProfile, buffer, addresses, timestamps);
+            }
+
+            bootstrapWordCount = 0;
+        }
+
+        private DecodeQuality chooseBestProfile(final int totalWords) {
+            DecodeQuality best = null;
+            for (final DecodeProfile profile : DecodeProfile.values()) {
+                final DecodeQuality candidate = evaluateDecodeQuality(profile, totalWords);
+                if ((best == null) || isBetterQuality(candidate, best)) {
+                    best = candidate;
+                }
+            }
+            return best;
+        }
+
+        private boolean isBetterQuality(final DecodeQuality candidate, final DecodeQuality incumbent) {
+            if (candidate.eventCount != incumbent.eventCount) {
+                return candidate.eventCount > incumbent.eventCount;
+            }
+            if (candidate.resetCount != incumbent.resetCount) {
+                return candidate.resetCount < incumbent.resetCount;
+            }
+            if (candidate.nonMonotonicCount != incumbent.nonMonotonicCount) {
+                return candidate.nonMonotonicCount < incumbent.nonMonotonicCount;
+            }
+            if (candidate.wrapCount != incumbent.wrapCount) {
+                return candidate.wrapCount > incumbent.wrapCount;
+            }
+            return candidate.profile.ordinal() < incumbent.profile.ordinal();
+        }
+
+        private DecodeQuality evaluateDecodeQuality(final DecodeProfile profile, final int totalWords) {
+            final DecodeQuality quality = new DecodeQuality(profile);
+            int wrapAddTmp = 0;
+            int lastTimestampTmpLocal = 0;
+
+            for (int idx = 0; idx < totalWords; idx++) {
+                final int rawWord = bootstrapRawWords[idx];
+                final int b0 = rawWord & 0xFF;
+                final int b1 = (rawWord >>> 8) & 0xFF;
+                final int b2 = (rawWord >>> 16) & 0xFF;
+                final int b3 = (rawWord >>> 24) & 0xFF;
+                final int markerByte = markerByteForProfile(b2, b3, profile);
+                final int wordType = classifyWord(markerByte, profile);
+
+                if (wordType == WORD_WRAP) {
+                    quality.wrapCount++;
+                    wrapAddTmp += wrapIncrementForProfile(profile);
+                } else if (wordType == WORD_RESET) {
+                    quality.resetCount++;
+                    wrapAddTmp = 0;
+                    lastTimestampTmpLocal = 0;
+                } else {
+                    quality.eventCount++;
+                    final int shortTimestamp = shortTimestampForProfile(b2, b3, profile);
+                    final int timestamp = TICK_US * (shortTimestamp + wrapAddTmp);
+                    if (timestamp < lastTimestampTmpLocal) {
+                        quality.nonMonotonicCount++;
+                    }
+                    lastTimestampTmpLocal = timestamp;
+                    final int address = addressForProfile(b0, b1, profile);
+                    if ((address & 0xFFFF) == 0xFFFF) {
+                        quality.nonMonotonicCount++;
+                    }
+                }
+            }
+            return quality;
+        }
+
+        private void processWord(final int rawWord, final int b0, final int b1, final int b2, final int b3,
+                final DecodeProfile profile, final AEPacketRaw buffer, final int[] addresses, final int[] timestamps) {
+            final int markerByte = markerByteForProfile(b2, b3, profile);
+            final int wordType = classifyWord(markerByte, profile);
+
+            if (wordType == WORD_WRAP) {
+                wrapAdd += wrapIncrementForProfile(profile);
+                logDebugWordIfEnabled(rawWord, b0, b1, b2, b3, "wrap", -1, -1, profile, markerByte);
+                return;
+            }
+            if (wordType == WORD_RESET) {
+                // For reset markers from hardware, reset local unwrap state only.
+                // Do not send resetTimestamps() back to device from stream parser.
+                wrapAdd = 0;
+                lastTimestampTmp = 0;
+                logDebugWordIfEnabled(rawWord, b0, b1, b2, b3, "reset", -1, -1, profile, markerByte);
+                final boolean suppressLegacyTimestampWarning = shouldSuppressLegacyTimestampWarning();
+                if ((resetTimestampWarningCount < RESET_TIMESTAMPS_INITIAL_PRINTING_LIMIT)
+                        || ((resetTimestampWarningCount % RESET_TIMESTAMPS_WARNING_INTERVAL) == 0)) {
+                    final int resetShortTs = shortTimestampForProfile(b2, b3, profile) & 0x3FFF;
+                    if (suppressLegacyTimestampWarning) {
+                        CypressFX2.log.info(this + ".translateEvents got reset event from hardware, timestamp "
+                                + resetShortTs + " (USBAERmini2 timestamp stream validated)");
+                    } else {
+                        CypressFX2.log.info(this + ".translateEvents got reset event from hardware, timestamp "
+                                + resetShortTs);
+                    }
+                }
+                if (!suppressLegacyTimestampWarning && (resetTimestampWarningCount == RESET_TIMESTAMPS_INITIAL_PRINTING_LIMIT)) {
+                    CypressFX2.log.warning("will only print reset timestamps message every "
+                            + RESET_TIMESTAMPS_WARNING_INTERVAL + " times now\n"
+                            + "If you are injecting sync events using the DVS128 IN pin, try enabling sync events output in the DVS128 menu.");
+                }
+                resetTimestampWarningCount++;
+                return;
+            }
+
+            if ((eventCounter > (aeBufferSize - 1)) || (buffer.overrunOccuredFlag)) {
+                buffer.overrunOccuredFlag = true;
+                return;
+            }
+
+            final int address = addressForProfile(b0, b1, profile);
+            final int shortTimestamp = shortTimestampForProfile(b2, b3, profile);
+            final int timestamp = TICK_US * (shortTimestamp + wrapAdd);
+            addresses[eventCounter] = address;
+            timestamps[eventCounter] = timestamp;
+            logDebugWordIfEnabled(rawWord, b0, b1, b2, b3, "event", address, shortTimestamp, profile, markerByte);
+
+            final boolean nonMonotonic = timestamp < lastTimestampTmp;
+            if (nonMonotonic) {
+                CypressFX2.log.info(String.format("nonmonotonic timestamp: lastTimestamp=%,d, timestamp=%,d, dt=%,d",
+                        lastTimestampTmp,
+                        timestamp,
+                        (lastTimestampTmp - timestamp)));
+            }
+            updateTimestampHealth(timestamp, nonMonotonic);
+            lastTimestampTmp = timestamp;
+
+            if ((addresses[eventCounter] & CypressFX2LibUsbDVS128HardwareInterface.SYNC_EVENT_BITMASK) != 0) {
+                if (printedSyncEventWarningCount < 10) {
+                    if (printedSyncEventWarningCount < 10) {
+                        CypressFX2.log.info("sync event at timestamp=" + timestamps[eventCounter]);
+                    } else {
+                        CypressFX2.log.warning("disabling further printing of sync events");
+                    }
+                    printedSyncEventWarningCount++;
+                }
+            }
+            eventCounter++;
+            buffer.setNumEvents(eventCounter);
+            maybeLogDecodedRate();
+        }
+
+        private int addressForProfile(final int b0, final int b1, final DecodeProfile profile) {
+            if ((profile == DecodeProfile.CPLD_BE) || (profile == DecodeProfile.ORIGINAL_BE)) {
+                return (b0 << 8) | b1;
+            }
+            return b0 | (b1 << 8);
+        }
+
+        private int shortTimestampForProfile(final int b2, final int b3, final DecodeProfile profile) {
+            if ((profile == DecodeProfile.CPLD_BE) || (profile == DecodeProfile.ORIGINAL_BE)) {
+                return (b2 << 8) | b3;
+            }
+            return b2 | (b3 << 8);
+        }
+
+        private int markerByteForProfile(final int b2, final int b3, final DecodeProfile profile) {
+            if ((profile == DecodeProfile.CPLD_BE) || (profile == DecodeProfile.ORIGINAL_BE)) {
+                return b2;
+            }
+            return b3;
+        }
+
+        private boolean isCpldProfile(final DecodeProfile profile) {
+            return (profile == DecodeProfile.CPLD_LE) || (profile == DecodeProfile.CPLD_BE);
+        }
+
+        private int wrapIncrementForProfile(final DecodeProfile profile) {
+            return isCpldProfile(profile) ? 0x4000 : 0x8000;
+        }
+
+        private int classifyWord(final int markerByte, final DecodeProfile profile) {
+            if ((markerByte & 0x80) == 0x80) {
+                return WORD_WRAP;
+            }
+            // In the original USBAERmini2 firmware mode, bit 0x40 is normal timestamp data,
+            // not a reset marker. Only CPLD profiles treat 0x40 as reset.
+            if (isCpldProfile(profile) && ((markerByte & 0x40) == 0x40)) {
+                return WORD_RESET;
+            }
+            return WORD_EVENT;
+        }
+
+        private void maybeLogDecodedRate() {
+            if (!isUsbaermini2 || !debugWordDumpEnabled) {
+                return;
+            }
+            rateWindowDecodedEvents++;
+            final long nowNs = System.nanoTime();
+            final long dtNs = nowNs - rateWindowStartNs;
+            if (dtNs >= 1_000_000_000L) {
+                final long rate = Math.round((rateWindowDecodedEvents * 1_000_000_000d) / dtNs);
+                CypressFX2.log.info(String.format("USBAERmini2 decodedEventsPerSecond=%d (profile=%s)", rate, decodeProfile));
+                rateWindowStartNs = nowNs;
+                rateWindowDecodedEvents = 0;
+            }
+        }
+
+        private void logDebugWordIfEnabled(final int rawWord, final int b0, final int b1, final int b2, final int b3,
+                final String type, final int address, final int shortts, final DecodeProfile profile, final int markerByte) {
+            if (!isUsbaermini2 || !debugWordDumpEnabled || (debugWordDumpCount >= debugWordDumpLimit)) {
+                return;
+            }
+
+            final String eventFields = (address >= 0) ? String.format(", addr=0x%04X, shortts=0x%04X", address, shortts) : "";
+            CypressFX2.log.info(String.format(
+                    "USBAERmini2 decode[%d]: bytes=%02X %02X %02X %02X rawLE=0x%08X profile=%s marker=0x%02X type=%s wrapAdd=%d%s",
+                    debugWordDumpCount, b0, b1, b2, b3, rawWord, profile, markerByte, type, wrapAdd, eventFields));
+            debugWordDumpCount++;
         }
     }
 

--- a/src/net/sf/jaer/hardwareinterface/usb/cypressfx2libusb/LibUsbHardwareInterfaceFactory.java
+++ b/src/net/sf/jaer/hardwareinterface/usb/cypressfx2libusb/LibUsbHardwareInterfaceFactory.java
@@ -76,6 +76,8 @@ public class LibUsbHardwareInterfaceFactory implements HardwareInterfaceFactoryI
 //        addDeviceToMap(CypressFX2.VID_DVS128_ORIG_FX2_ONLY, CypressFX2.PID_TMPDIFF128_RETINA, CypressFX2TmpdiffRetinaHardwareInterface.class);
         addDeviceToMap(CypressFX2.VID_THESYCON_FX2_CPLD, CypressFX2.PID_COCHLEAAMS, CochleaAMS1cHardwareInterface.class);
 
+        addDeviceToMap((short) 0x0547, (short) 0x8801, CypressFX2LibUsbDVS128HardwareInterface.class);
+
         // Linux Drivers for PAER retina.
         if (System.getProperty("os.name").startsWith("Linux")) {
             addDeviceToMap(CypressFX2.VID_THESYCON_FX2_CPLD, SiLabsC8051F320_LibUsb_PAER.PID_PAER, SiLabsC8051F320_LibUsb_PAER.class);


### PR DESCRIPTION
## Summary

This PR restores working support for USBAERmini2 on modern jAER builds running on current JDK and NetBeans versions.

## Changes made

* Updated `CypressFX2.java`
* Updated `CypressFX2LibUsbDVS128HardwareInterface.java`
* Updated `LibUsbHardwareInterfaceFactory.java`

## Motivation

I was unable to get my DVS128 / USBAERmini2 setup working correctly with the current configuration, so I applied these changes to restore proper behavior in my local setup.

*Problem*:
- Device was detected but events were not rendered correctly
- Timestamp handling produced misleading warnings
- Legacy assumptions from older jAER code paths were no longer valid on the modern libusb path

## Notes

* The changes were tested in a local working environment.
* Please let me know if you would prefer the changes split into smaller commits or adapted to project conventions.

*Changes*:
- Added/updated USB VID/PID mapping for USBAERmini2
- Restored compatible event decoding path for the device
- Improved timestamp health/diagnostic handling
- Preserved operation on modern JDK without requiring legacy Java 8 setup

*Tested on*:
- Windows 11
- NetBeans IDE 24
- modern JDK
- USBAERmini2 (VID/PID 0547:8801)

*Validation*:
- camera is detected
- events are visualized correctly
- timestamps advance correctly
- diagnostics report healthy timestamp stream